### PR TITLE
Fixing scrollbar issue

### DIFF
--- a/components/AppNav.vue
+++ b/components/AppNav.vue
@@ -42,7 +42,7 @@ div {
   align-items: center;
   display: flex;
   height: 100%;
-  width: 100vw;
+  width: 100%;
 }
 
 ul {


### PR DESCRIPTION
The bottom scrollbar was enabled because the nav got a too wide size


![image](https://user-images.githubusercontent.com/32040951/72681310-9240ad00-3ac2-11ea-87ae-eaf2d2cb1b7b.png)
